### PR TITLE
added prefix global to __CLIENT__

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -8,7 +8,7 @@ export function configureStore(env, initialState) {
 
   const store = compose(
     applyMiddleware(thunk),
-    (__CLIENT__ && dev && window.devToolsExtension) ? window.devToolsExtension() : f => f,
+    (global.__CLIENT__ && dev && window.devToolsExtension) ? window.devToolsExtension() : f => f,
   )(createStore)(rootReducer, initialState)
 
   if (dev && module.hot) {


### PR DESCRIPTION
sometimes throws an error: __CLIENT__ is not defined, added global. prefix to fix that
